### PR TITLE
make rowRenderIndex available to GridRow

### DIFF
--- a/src/js/core/directives/ui-grid-row.js
+++ b/src/js/core/directives/ui-grid-row.js
@@ -25,6 +25,9 @@
 
             // Function for attaching the template to this scope
             var clonedElement, cloneScope;
+            Object.getPrototypeOf($scope.row).rowIndex = null;
+            $scope.row.rowIndex = $scope.rowRenderIndex;
+            
             function compileTemplate() {
               $scope.row.getRowTemplateFn.then(function (compiledElementFn) {
                 // var compiledElementFn = $scope.row.compiledElementFn;


### PR DESCRIPTION
I am looking to do something similar to issue #2958 but I want the rowIndex to be made available during the compile phase.
If there's a better way to do this I am 100% open to suggestions.
